### PR TITLE
FLUID-6465: Disallow top-level references to gpii in the linter configuration

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -29,7 +29,6 @@
 
     "globals": {
         "fluid": false,
-        "gpii": true,
         "JSON": false
     }
 }


### PR DESCRIPTION
We don't need this entry in .jshintrc anymore since we've expunged all references to `gpii`.